### PR TITLE
flag duplicate releases

### DIFF
--- a/releases.py
+++ b/releases.py
@@ -157,7 +157,6 @@ class Release:
   def set_duplicate(self):
     self.is_duplicate = True
 
-
   def __repr__(self):
     return "Release(%s %s %s)" % (self.repo, self.release_num, TagType(self.stage))
 
@@ -175,11 +174,6 @@ class Component:
       tag_list = list(tags)
       release = Release(release_num, tag_list)
       releases.insert(0, release)
-      prev_release = release
-    rel_len = len(releases)
-    if rel_len >=2:
-      if releases[0].tags[0].get_merge_date()  == releases[1].tags[0].get_merge_date():
-          releases[0].set_duplicate()
 
     try:
       # find latest production deploy
@@ -211,6 +205,12 @@ class Component:
       
       release_num_cutoff = staging_release_num_cutoff
   
+    # identify release duplicates by comparing all pairs upt to and including current staging deploy
+    duplicate_candiates = list(filter(lambda r : (r.release_num >= release_num_cutoff), releases))
+    for release, prev in zip(duplicate_candiates, duplicate_candiates[1:]):
+      if release.tags[0].get_merge_date()  == prev.tags[0].get_merge_date():
+        release.set_duplicate()
+
     # get all created and approved releases, but don't bother showing anything below staging version
     # get releases and approved releases, but don't bother showing anything below staging's current version
     self.releases = list(filter(lambda r : (r.release_num > release_num_cutoff) and \

--- a/static/hud.css
+++ b/static/hud.css
@@ -122,7 +122,6 @@ html, body {
   color: white!important;
 }
 
-
 .number {
   position: absolute; top: 0; left: 0; width: 25%; height: 1.8em; font-size: 2em; line-height: 1.8em; 
 }
@@ -153,6 +152,10 @@ html, body {
 
 .info.alarm { 
     background-color: #BF1E2D;
+}
+
+.info.duplicate {
+  background-color: lightgray
 }
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
         <td class="releases">          
           <div style="width: 100%; height: 6.8em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; ">
             {% for release in component.releases %}
-              {% if release.is_duplicate == 'duplicate' %}
+              {% if release.is_duplicate %}
                 {% include 'release-duplicate.html' %}
               {% elif release.stage == TagType.RELEASE_APPROVED%}
                 {% include 'release-approved.html' %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,9 @@
         <td class="releases">          
           <div style="width: 100%; height: 6.8em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; ">
             {% for release in component.releases %}
-              {% if release.stage == TagType.RELEASE_APPROVED %}
+              {% if release.is_duplicate == 'duplicate' %}
+                {% include 'release-duplicate.html' %}
+              {% elif release.stage == TagType.RELEASE_APPROVED%}
                 {% include 'release-approved.html' %}
               {% else %}
                 {% include 'release-created.html' %}

--- a/templates/release-duplicate.html
+++ b/templates/release-duplicate.html
@@ -1,0 +1,5 @@
+{% extends "release.html" %}
+
+{% block warning %}
+    <div class="info duplicate">Duplicate</div>
+{% endblock %}


### PR DESCRIPTION
As a first step to solving duplicate release problem it is useful to easily be able to see them. This PR identifies duplicates using release merge date, and flags them with grey info bar and duplicate label

<img width="1432" alt="screen shot 2017-04-06 at 15 02 52" src="https://cloud.githubusercontent.com/assets/1420504/24758403/2b5b5316-1ada-11e7-8e9d-fa5a2c2f661f.png">
