### PR TITLE
PP-2610 Reverting `pay-products-ui`

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ app = Flask(__name__)
 def start():
   try:
     components = []
-    for repo in ('pay-frontend', 'pay-selfservice', 'pay-connector', 'pay-publicapi', 'pay-cardid', 'pay-publicauth', 'pay-adminusers', 'pay-products', 'pay-products-ui'):
+    for repo in ('pay-frontend', 'pay-selfservice', 'pay-connector', 'pay-publicapi', 'pay-cardid', 'pay-publicauth', 'pay-adminusers', 'pay-products'):
       components.append(Component(Repo('alphagov', repo)))
     
     components_behind = 0


### PR DESCRIPTION
It seems release-hud breaks when there is no releases. Reverting `pay-products-ui` until we get the first release